### PR TITLE
Support python3.4 where json.loads() only supports str

### DIFF
--- a/varlink/client.py
+++ b/varlink/client.py
@@ -177,7 +177,7 @@ class SimpleClientInterfaceHandler(ClientInterfaceHandler):
         :param interface: an Interface object
         :param file_or_socket: an open socket or io stream
         :param namespaced: if True, varlink methods return SimpleNamespace objects instead of dictionaries
-        
+
         """
         ClientInterfaceHandler.__init__(self, interface, namespaced=namespaced)
         self._connection = file_or_socket
@@ -228,7 +228,7 @@ class SimpleClientInterfaceHandler(ClientInterfaceHandler):
                 message = None
 
             if message:
-                yield message
+                yield message.decode('utf-8')
                 continue
 
             if self._recv:

--- a/varlink/server.py
+++ b/varlink/server.py
@@ -227,7 +227,8 @@ class Service(object):
         if message[-1] == 0:
             message = message[:-1]
 
-        handle = self._handle(json.loads(message), message, _server, _request)
+        string = message.decode('utf-8')
+        handle = self._handle(json.loads(string), message, _server, _request)
         for out in handle:
             if out == None:
                 return


### PR DESCRIPTION
- Decode binary buffers prior to parsing to JSON object
- Python>=3.6 json.loads() supports buffers of type str, bytes or bytearrary

Code passes certification tests using python 3.4

Fixes: #7

Signed-off-by: Jhon Honce <jhonce@redhat.com>