### PR TITLE
Improve packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,9 @@
 /.cache
 /.coverage
 /.pytest_cache
-
+*.eggs/
+*__pycache__*
+dist/
+*.swa
+*.swp
+build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,13 @@ install:
 - pip install tox-travis .[devel]
 - pip install -r test-requirements.txt
 script:
+# Check packaging first (README format etc...)
+- pip install -U setuptools
+- pip install -U wheel
+- pip install -U twine
+- python setup.py sdist
+- python setup.py bdist_wheel
+- twine check dist/*
 - tox
 - "python -m varlink.cli -A 'python -m varlink.tests.test_orgexamplemore --varlink=$VARLINK_ADDRESS' call org.example.more.Ping '{  \"ping\": \"Ping\" }'"
 - PYTHONPATH=$(pwd) python ./varlink/tests/test_certification.py
@@ -29,3 +36,11 @@ notifications:
     on_failure: always  # options: [always|never|change] default: always
     on_start: never     # options: [always|never|change] default: always
 
+deploy:
+  - provider: pypi
+    user: varlink
+    password: your-secure-password
+    on:
+      tags: true
+    distributions: sdist bdist_wheel
+    skip_existing: true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,36 @@
+[metadata]
+name = varlink
+description = Python implementation of the Varlink protoco
+long_description = file: README.md
+long_description_content_type = text/markdown
+author = Lars Karlitski<lars@karlitski.net>, Harald Hoyer<harald@redhat.com>
+author_email = harald@redhat.com
+url = https://github.com/varlink/python
+keywords = ipc, varlink, rpc
+license = ASL 2.0
+classifiers =
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Topic :: System :: Networking
+
+[options]
+zip_safe = False
+python_requires=>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*
+include_package_data = True
+packages = varlink
+setup_requires =
+  setuptools_scm
+
+[options.package_data]
+varlink = *.varlink
+
+[bdist_wheel]
+universal = 1
+

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,6 @@
 python-coveralls
 future
-stestr
+coverage
+fixtures
+nose
+nose-timer

--- a/tox.ini
+++ b/tox.ini
@@ -17,26 +17,16 @@ deps =
     -r{toxinidir}/test-requirements.txt
     -r{toxinidir}/requirements.txt
 commands =
-    stestr run --slowest {posargs} --test-path varlink/tests
+    nosetests \
+    --with-timer \
+    --with-coverage --cover-erase --cover-package=varlink
 
 [testenv:py27]
-deps =
-    coverage
-    fixtures
-    nose
-    nose-timer
 commands =
     nosetests \
     --with-timer \
     --with-coverage --cover-erase --cover-package=varlink \
     --exclude=(test_mocks.py)
-
-[testenv:coverage]
-setenv =
-    PYTHON=coverage run --source varlink --parallel-mode
-commands =
-    stestr run '{posargs}' --test-path varlink/tests
-    coverage combine
 
 [travis]
 python = 3.7: py37


### PR DESCRIPTION
- display readme.md content on pypi
- retrieve version from scm (git tag in our case)
- automatically deploy a new release on pypi when we push a git tag on github
- prefer cfg file to host project package config instead of python code

If you accept these changes then after you need to update the deploy section inside the `.travis.yml` file and you need to encrypt your password.

For further reading about how to deploy on pypi from travis you can read these docs:
- https://docs.travis-ci.com/user/encryption-keys/
- https://docs.travis-ci.com/user/deployment/pypi/

Also at each github push, CI will check readme syntax, packaging, etc, too

With these changes the next time you will push a new git tag on github it will build and deploy a related release on pypi automatically.