### PR TITLE
Add the development status classifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ url = https://github.com/varlink/python
 keywords = ipc, varlink, rpc
 license = ASL 2.0
 classifiers =
+    Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python


### PR DESCRIPTION
Will fix the README badge `status` blank.

Will inform users that varlink is stable.

Allow users to search for stable projects on pypi