### PR TITLE
Remove useless deployment scripts part

### DIFF
--- a/newversion.sh
+++ b/newversion.sh
@@ -11,15 +11,6 @@ if [[ -z "$version" ]]; then
 fi
 
 sed -i -e "s/^Version.*/Version: \\t${version}/" python-varlink.spec
-sed -i -e "s/^[ \\t]*version.*=.*/    version = \"${version}\",/" setup.py
-git commit -m "version ${version}" python-varlink.spec setup.py
-git tag -m "version ${version}" --sign "${version}"
-git push
-git push --tags
-rm -fr dist
-python3 setup.py bdist_wheel --universal
-python3 setup.py sdist
-twine upload --skip-existing --sign-with gpg2 -s dist/*
 curl -L -O https://github.com/varlink/python-varlink/archive/${version}/python-varlink-${version}.tar.gz
 rm -fr docs/build
 python3 setup.py build_sphinx --source-dir=docs/ --build-dir=docs/build --all-files


### PR DESCRIPTION
python-varlink is now deployed on pypi through git tag creation and travis
triggering, so we can now remove some useless part of the deployment script.