### PR TITLE
cli: fix calling a method when the server is identified by its address

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ method StopServing() -> ()
 # Something failed in TestMore
 error TestMoreError (reason: string)
 
+$ python -m varlink.cli call unix:/tmp/test/org.example.more.Ping '{ "ping": "Ping"}'
+{
+  "pong": "Ping"
+}
+ 
 
 $ fg
 python3 -m varlink.tests.test_orgexamplemore --varlink="unix:/tmp/test"

--- a/varlink/cli.py
+++ b/varlink/cli.py
@@ -27,11 +27,15 @@ def varlink_call(args):
     method = args.METHOD[deli + 1:]
     interface = args.METHOD[:deli]
 
-    def new_client(interface):
-        deli = interface.rfind("/")
-        if deli != -1:
-            address = interface[:deli]
-            interface = interface[deli + 1:]
+    deli = interface.rfind("/")
+    if deli != -1:
+        address = interface[:deli]
+        interface = interface[deli + 1:]
+    else:
+        address = None
+
+    def new_client(address):
+        if address:
             client = varlink.Client.new_with_address(address)
         else:
             if args.activate:
@@ -42,7 +46,7 @@ def varlink_call(args):
                 client = varlink.Client.new_with_resolved_interface(interface, args.resolver)
         return client
 
-    with new_client(interface) as client:
+    with new_client(address) as client:
         got = False
         try:
             with client.open(interface) as con:


### PR DESCRIPTION
Inner function new_client tries to write to its parameter and expects the outer function to read the modified value. This obviously does not work, so move the parsing code out of new_client.

There are no CLI unit tests, but the command that now works is included in `README.md`. Before:
```
$ python -m varlink.cli call unix:/tmp/test/org.example.more.Ping '{ "ping": "Ping"}'
{'error': 'org.varlink.service.InterfaceNotFound', 'parameters': {'interface': 'unix:/tmp/test/org.example.more'}}
```

After:
```
$ python -m varlink.cli call unix:/tmp/test/org.example.more.Ping '{ "ping": "Ping"}'
{
  "pong": "Ping"
}
```