### PR TITLE
ci: update checkout action to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
   tox_test:
     name: Tox test
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Run Tox tests
         id: test
         uses: fedora-python/tox-github-action@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python 3.9


### PR DESCRIPTION
actions/checkout@v4 uses nodejs 20 as runtime instead of the deprecated nodejs 12 runtime.