### PR TITLE
fix: drop unneeded fixtures test dependency

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,1 @@
-fixtures
 nose2


### PR DESCRIPTION
Originally introduced in e736c6636ef11987d868 when the test setup still used nose and with nose2 this no longer seems to be required.