### PR TITLE
README.md: Update python invocation in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ See the [tests](https://github.com/varlink/python-varlink/tree/master/varlink/te
 ```bash
 $ python3 -m varlink.tests.test_orgexamplemore --varlink="unix:/tmp/test" &
 [1] 6434
-$ python -m varlink.cli help unix:/tmp/test/org.example.more
+$ python3 -m varlink.cli help unix:/tmp/test/org.example.more
 # Example Varlink service
 interface org.example.more
 
@@ -56,7 +56,7 @@ method StopServing() -> ()
 # Something failed in TestMore
 error TestMoreError (reason: string)
 
-$ python -m varlink.cli call unix:/tmp/test/org.example.more.Ping '{ "ping": "Ping"}'
+$ python3 -m varlink.cli call unix:/tmp/test/org.example.more.Ping '{ "ping": "Ping"}'
 {
   "pong": "Ping"
 }


### PR DESCRIPTION
I've starting using this repository recently, and saw a discrepancy in the README.md examples, which made some of the examples not work on my machine, which does not contain the `python` alias in the path.  
The commit updates the readme, to always invoke the examples with `python3`.

The code examples in the README.md file were inconsistent - some of them were invoking the code with `python`, which others were using `python3` explicitly.

This commit updates the examples in this file to always invoke the code with `python3`, to ensure they are also working in systems where `python` is not available.