### PR TITLE
package: Drop setuptools_scm_git_archive requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "setuptools >= 48",
-    "setuptools_scm[toml]",
-    "setuptools_scm_git_archive",
+    "setuptools_scm[toml] >= 7.0.0",
     "wheel >= 0.29.0",
 ]
 build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
The tool of setuptools_scm_git_archive is deprecated. The logic of this package was introduced directly to the setuptools_scm package, since version 7.0.0 of this package.

This commit removes the unnecessary requirement to have setuptools_scm_git_archive, and instead, ensures that the setuptools_scm version used is recent enough.