### PR TITLE
Drop Python 2 support in the spec file

### DIFF
--- a/python-varlink.spec
+++ b/python-varlink.spec
@@ -1,7 +1,3 @@
-%if 0%{?fedora} || 0%{?rhel} >= 8
-%global build_py3   1
-%endif
-
 Name:           python-varlink
 Version: 	30.3.1
 Release:        1%{?dist}
@@ -11,15 +7,10 @@ URL:            https://github.com/varlink/%{name}
 Source0:        https://github.com/varlink/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
 BuildArch:      noarch
 
-BuildRequires:  python2-devel
-BuildRequires:  python-rpm-macros
-BuildRequires:  python-setuptools
-BuildRequires:  python-setuptools_scm
-
-%if 0%{?build_py3}
 BuildRequires:  python3-devel
 BuildRequires:  python3-rpm-macros
-%endif
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-setuptools_scm
 
 
 %global _description \
@@ -27,57 +18,30 @@ An python module for Varlink with client and server support.
 
 %description %_description
 
-%package -n     python2-varlink
-Summary:        %summary
-%{?python_provide:%python_provide python2-varlink}
-
-
-%if 0%{?build_py3}
 %package -n python3-varlink
 Summary:       %summary
 %{?python_provide:%python_provide python3-varlink}
-%endif
 
-%description -n python2-varlink %_description
-
-%if 0%{?build_py3}
 %description -n python3-varlink %_description
-%endif
 
 %prep
 %autosetup -n python-%{version}
 
 %build
 export SETUPTOOLS_SCM_PRETEND_VERSION=%{version}
-%py2_build
-%if 0%{?build_py3}
 %py3_build
-%endif
 
-
-%if 0%{?build_py3}
 %check
 export SETUPTOOLS_SCM_PRETEND_VERSION=%{version}
 CFLAGS="%{optflags}" %{__python3} %{py_setup} %{?py_setup_args} check
-%endif
 
 %install
 export SETUPTOOLS_SCM_PRETEND_VERSION=%{version}
-%py2_install
-%if 0%{?build_py3}
 %py3_install
-%endif
 
-%files -n python2-varlink
-%license LICENSE.txt
-%doc README.md
-%{python2_sitelib}/*
-
-%if 0%{?build_py3}
 %files -n python3-varlink
 %license LICENSE.txt
 %doc README.md
 %{python3_sitelib}/*
-%endif
 
 %changelog


### PR DESCRIPTION
Python 2 support was already dropped in b9aa56dc3f503b711430e2c9d0bc7.

---

Did a local test mockbuild which succeeded, there is a question if this spec file should stay in the repository as it uses the second last release (30.3.1) instead of 31.0.0 which is the latest release and there is no automatic machinery to bump it.

What might be interesting is to switch to packit so on tag/release a pull request is send to [pagure](https://src.fedoraproject.org/rpms/python-varlink/blob/rawhide/f/python-varlink.spec) to automatically bump the package in Fedora.