### PR TITLE
ci: update runner image to ubuntu-24.04

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The Ubuntu 20.04 image was already removed on 2025-04-15.

---

Failing run https://github.com/varlink/python/actions/runs/14617042271/job/41007534210

Tested on my fork https://github.com/jelly/python-varlink/actions/runs/14617363187/job/41008552562

Obviously fails due to lack of secrets but seems to run fine.