### PR TITLE
certification server: Do not emit an extraneous client_id from Test09

### DIFF
--- a/varlink/tests/test_certification.py
+++ b/varlink/tests/test_certification.py
@@ -287,7 +287,6 @@ class CertService:
         self.assert_cmp(client_id, _server, _raw, wants, "two" in _set)
         self.assert_cmp(client_id, _server, _raw, wants, "three" in _set)
         return {
-            "client_id": client_id,
             "mytype": {
                 "object": {
                     "method": "org.varlink.certification.Test09",


### PR DESCRIPTION
The interface definition of the Test09 method does not allow a client_id field to be returned. Other implementations may reject the response due to not expecting that field. Drop it.

Closes: #54