### PR TITLE
Remove keyword argument to getattr

### DIFF
--- a/varlink/server.py
+++ b/varlink/server.py
@@ -181,9 +181,7 @@ class Service:
 
             if self._namespaced:
                 # FIXME: check for Maybe before taking None as default value
-                out = func(
-                    *(getattr(parameters, k, None) for k in method.in_type.fields.keys()), **kwargs
-                )
+                out = func(*(getattr(parameters, k, None) for k in method.in_type.fields.keys()), **kwargs)
             else:
                 # FIXME: check for Maybe before taking None as default value
                 out = func(*(parameters.get(k) for k in method.in_type.fields.keys()), **kwargs)

--- a/varlink/server.py
+++ b/varlink/server.py
@@ -182,7 +182,7 @@ class Service:
             if self._namespaced:
                 # FIXME: check for Maybe before taking None as default value
                 out = func(
-                    *(getattr(parameters, k, default=None) for k in method.in_type.fields.keys()), **kwargs
+                    *(getattr(parameters, k, None) for k in method.in_type.fields.keys()), **kwargs
                 )
             else:
                 # FIXME: check for Maybe before taking None as default value


### PR DESCRIPTION
getattr doesn't support keyword arguments for recent python versions at least; I was trying to use the server and would constantly encounter this error:

```
Traceback (most recent call last):
  File "<>/lib/python3.12/socketserver.py", line 697, in process_request_thread
    self.finish_request(request, client_address)
  File "<>/lib/python3.12/socketserver.py", line 362, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "<>/lib/python3.12/socketserver.py", line 766, in __init__
    self.handle()
  File "<>/varlink/server.py", line 349, in handle
    for reply in self.service.handle(message, _server=self.server, _request=self.request):
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<>/varlink/server.py", line 243, in handle
    for out in handle:
               ^^^^^^
  File "/<>/varlink/server.py", line 184, in _handle
    out = func(*(getattr(parameters, k, None) for k in method.in_type.fields.keys()), **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<>/varlink/server.py", line 184, in <genexpr>
    out = func(*(getattr(parameters, k, None) for k in method.in_type.fields.keys()), **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: getattr() takes no keyword arguments

```


Just to make sure it wasn't anything custom:
```
cat test.py
getattr(1, 'a', default=None)


for p in 3.10 3.11 3.12 3.13 3.14; do echo "Python $p"; uv run --python $p test.py; echo; done

Python 3.10
Traceback (most recent call last):
  File "/home/kunalb/rough/2025/06/20/test.py", line 1, in <module>
    getattr(1, 'a', default=None)
TypeError: getattr() takes no keyword arguments

Python 3.11
Traceback (most recent call last):
  File "/home/kunalb/rough/2025/06/20/test.py", line 1, in <module>
    getattr(1, 'a', default=None)
TypeError: getattr() takes no keyword arguments

Python 3.12
Traceback (most recent call last):
  File "/home/kunalb/rough/2025/06/20/test.py", line 1, in <module>
    getattr(1, 'a', default=None)
TypeError: getattr() takes no keyword arguments

Python 3.13
Traceback (most recent call last):
  File "/home/kunalb/rough/2025/06/20/test.py", line 1, in <module>
    getattr(1, 'a', default=None)
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
TypeError: getattr() takes no keyword arguments

Python 3.14
Traceback (most recent call last):
  File "/home/kunalb/rough/2025/06/20/test.py", line 1, in <module>
    getattr(1, 'a', default=None)
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
TypeError: getattr() takes no keyword arguments
```