### PR TITLE
ci: temporary pin tox to 4.29.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,8 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install tox
-        run: python -m pip install tox
+        # https://github.com/tox-dev/tox/issues/3602
+        run: python -m pip install 'tox<4.30'
       - name: Run ruff format
         run: |
           tox -e ruff-format


### PR DESCRIPTION
4.30 breaks when setup.cfg doesn't contain tox configuration, even though it is configured in pyproject.toml.