### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 [![Varlink Certified](https://img.shields.io/badge/varlink-certified-green.svg)](https://www.varlink.org/Language-Bindings)
-[![Build Status](https://travis-ci.org/varlink/python.svg?branch=master)](https://travis-ci.org/varlink/python)
-[![Coverage Status](https://coveralls.io/repos/github/varlink/python/badge.svg?branch=master)](https://coveralls.io/github/varlink/python?branch=master)
 [![PyPI](https://img.shields.io/pypi/v/varlink.svg)](https://pypi.org/project/varlink/)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/varlink.svg)](https://pypi.org/project/varlink/)
 [![PyPI - Status](https://img.shields.io/pypi/status/varlink.svg)](https://pypi.org/project/varlink/)
@@ -14,14 +12,19 @@ A [varlink](http://varlink.org) implementation for Python.
 
 ## python varlink installation
 
-From pypi:
+From PyPI:
 ```bash
 $ pip3 install --user varlink
 ```
 
-With Fedora 28/rawhide:
+With Fedora:
 ```bash
 $ sudo dnf install python3-varlink
+```
+
+With Debian:
+```bash
+$ sudo apt install python3-varlink
 ```
 
 ## Examples


### PR DESCRIPTION
- drop travis build status, since we no longer use travis
- drop coverage badge, since it's wrong and last picked up a number in 2018
- fix PyPI capitalisation
- drop mention of really old Fedora
- mention the Debian package